### PR TITLE
fix: mjs, cjs module resolution to account for es6 node libraries

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -8,4 +8,10 @@ const config = getDefaultConfig(__dirname, {
   isCSSEnabled: true,
 });
 
+const { resolver } = config;
+config.resolver = {
+  ...resolver,
+  sourceExts: [...resolver.sourceExts, 'mjs', 'cjs'],
+};
+
 module.exports = withNativeWind(config, { input: './global.css' });


### PR DESCRIPTION
This PR will enable Class Variance Authority to work with metro bundler for expo web.