### PR TITLE
Lucide Icons only need color, size and strokeWidth props

### DIFF
--- a/app/(main)/(tabs)/_layout.tsx
+++ b/app/(main)/(tabs)/_layout.tsx
@@ -10,8 +10,8 @@ export default function TabsLayout() {
         name='index'
         options={{
           title: 'Example',
-          tabBarIcon(props) {
-            return <LayoutPanelLeft {...props} />;
+          tabBarIcon({color, size}) {
+            return <LayoutPanelLeft color={color} size={size} />;
           },
         }}
       />
@@ -19,8 +19,8 @@ export default function TabsLayout() {
         name='components'
         options={{
           title: 'Components',
-          tabBarIcon(props) {
-            return <MenuSquare {...props} />;
+          tabBarIcon({color, size}) {
+            return <MenuSquare color={color} size={size} />;
           },
         }}
       />


### PR DESCRIPTION
Resolves the following metro web error:

> Warning: Received `true` for a non-boolean attribute `focused`.
> If you want to write it to the DOM, pass a string instead: focused="true" or focused={value.toString()}.
 