### PR TITLE
Add https prefix to ui.shadcn.com url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Work in progress...
 
 # Re-usable UI
 
-Inspired by [ui.shadcn.com](ui.shadcn.com) with the purpose to be used as a reference to build your own component libraries.
+Inspired by [ui.shadcn.com](https://ui.shadcn.com) with the purpose to be used as a reference to build your own component libraries.
 
 **Progress**: 23 / 38 components
 


### PR DESCRIPTION
Case:
The url to the website "ui.shadcn.com" is not working correctly. I share a screenshot.
<img width="1254" alt="Captura de pantalla 2023-12-21 a las 9 18 15" src="https://github.com/mrzachnugent/rn-ui-inspired-by-shadcn/assets/12954959/8080e78b-4d18-437d-81ad-c6ba8e35da16">

Solution:
Add https in front of the link so that it opens as a website outside of Github.


